### PR TITLE
chore: add CI workflow for testing with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Run tests
+
+env:
+  QUARKUS_ANALYTICS_DISABLED: false
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    strategy:
+      matrix:
+        java-version: [17, 21]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up JDK ${{ matrix.java-version }}
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java-version }}
+        cache: maven
+
+    - name: Cache Maven repository
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Set up Maven
+      run: |
+        echo "MAVEN_OPTS=-Xmx2g" > ~/.mavenrc
+
+    - name: Run tests
+      run: ./mvnw quarkus:test

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar


### PR DESCRIPTION
Demo for https://github.com/bgizdov/quarkus-multi-module-project-quickstart/pull/9.

See the checks [here](https://github.com/codespearhead/quarkus-multi-module-project-quickstart/tree/chore/add-cd-workflow-for-testing-with-github-actions) and at the bottom of the current page.

![](https://i0.wp.com/deanattali.com/assets/img/blog/migrating-travis-to-github/gha.png?w=584&ssl=1)